### PR TITLE
Fix copier shell bug – replace source with direct call

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -28,7 +28,7 @@ _tasks:
   - "git init"
   - "uvx --from nblite nbl install-hooks"
   - "ln -s {{ module_name_slug }}/assets/config.toml ."
-  - "source .venv/bin/activate && nbl prepare"
+  - ".venv/bin/nbl prepare"
   - command: "git add --all && git reset */_scratch */api/core"
     when: "{{ initial_commit }}"
   - command: "git commit -m 'Repo created from template'"


### PR DESCRIPTION
This PR fixes a compatibility issue in copier.yml:

Replaces:
  source .venv/bin/activate && nbl prepare

With:
  .venv/bin/nbl prepare

This avoids shell failures in environments where 'source' is not available (e.g. /bin/sh).